### PR TITLE
Add default date header in mock response

### DIFF
--- a/lib/utils/mock.js
+++ b/lib/utils/mock.js
@@ -146,6 +146,7 @@ function match(req, res) {
   res.writeHead(200, {
     'Content-Length': Buffer.byteLength(content),
     'Cache-Control': 'max-age=0',
+    'Date': (new Date()).toUTCString(),
     'Content-Type': mime.getType(type),
     ...headers
   });


### PR DESCRIPTION
Add Date header in mock respone so that one can mock responses that can honor cache headers