### PR TITLE
Assume reloader is always running on localhost

### DIFF
--- a/src/reloader/reload-client.js
+++ b/src/reloader/reload-client.js
@@ -5,7 +5,7 @@
   }
   var sse;
   var retries;
-  var url = new URL(location.origin);
+  var url = new URL('localhost');
   url.port = $RELOAD_PORT;
   url.pathname = '/dvlpreload';
   connect();


### PR DESCRIPTION
In our setup due to various security restrictions we are required to run our development server behind a reverse HTTPS proxy. The reloader however uses `location.origin` to determine where to connect. As the [port itself is dynamic](https://github.com/popeindustries/dvlp/blob/master/src/reloader/index.js#L33) we can't proxy all possible ports.

This patch changes the origin to localhost.