### PR TITLE
Fix patch import resolving

### DIFF
--- a/src/utils/patch.js
+++ b/src/utils/patch.js
@@ -24,7 +24,7 @@ const { resolve } = require('../resolver/index.js');
 const { unzipSync } = require('zlib');
 
 const RE_CLOSE_BODY_TAG = /<\/body>/i;
-const RE_IMPORT = /^((?:\bimport\b[^'"&;:-=()]+|\bexport\b[^'"&;:-=()]+\sfrom\s)['"])([^'"\n]+)(['"])/gm;
+const RE_IMPORT = /((?:(?:^|[});]\s*)import\b[^'"&;:-=()]+|\bexport\b[^'"&;:-=()]+\sfrom\s)['"])([^'"\n]+)(['"])/gm;
 const RE_NONCE_SHA = /nonce-|sha\d{3}-/;
 const RE_OPEN_HEAD_TAG = /<head>/i;
 


### PR DESCRIPTION
ecd67b856534713fee5c4f3cfed865ef13cc0756 introduced a regression that prevented imports from being correctly rewritten when not appearing at the start of a line.

I've added tests for handling ASI tokens as well (http://www.ecma-international.org/ecma-262/7.0/index.html#sec-automatic-semicolon-insertion)