### PR TITLE
Don't rely on DVLP_VERSION from binary

### DIFF
--- a/bin/dvlp
+++ b/bin/dvlp
@@ -5,7 +5,6 @@ process.env.NODE_NO_WARNINGS = '1';
 const pkg = require('../package.json');
 
 process.env.DVLP_LAUNCHER = 'cmd';
-process.env.DVLP_VERSION = pkg.version;
 
 const program = require('commander');
 const { server } = require('../dvlp.js');

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ const path = require('path');
 const replace = require('@rollup/plugin-replace');
 const resolve = require('@rollup/plugin-node-resolve').default;
 const terser = require('terser');
+const pkg = require('./package.json');
 
 const reloadClient = terser.minify(
   fs.readFileSync('src/reloader/reload-client.js', 'utf8'),
@@ -41,6 +42,7 @@ module.exports = [
       replace({
         'global.$RELOAD_CLIENT': `'${reloadClient}'`,
         'global.$MOCK_CLIENT': `"${mockClient}"`,
+        'global.$VERSION': `'${pkg.version}'`,
       }),
       commonjs(),
       resolve(),

--- a/src/config.js
+++ b/src/config.js
@@ -12,7 +12,9 @@ const JS_MIME_TYPES = {
 const TESTING = process.env.NODE_ENV === 'dvlptest';
 // Prevent parallel test runs from reading from same cache
 const DIR = `.dvlp${TESTING ? process.getuid() : ''}`;
-const VERSION = process.env.DVLP_VERSION;
+
+// @ts-ignore
+const VERSION = global.$VERSION;
 
 const bundleDirName = `${path.join(DIR, `bundle-${VERSION}`)}`;
 const bundleDir = path.resolve(bundleDirName);


### PR DESCRIPTION
Previously using dvlp as a module would break caching between versions as `DVLP_VERSION` would be undefined.