### PR TITLE
add onResolveImport hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ module.exports = {
   },
 
   /**
+   * Manually resolve import specifier.
+   * This hook is run for each import statement.
+   * If returns "false", import re-writing is skipped.
+   * If returns "undefined", import specifier is re-written using default resolver.
+   * If "context.isDynamic", also possible to return replacement for whole expression.
+   *
+   * @param { string } specifier
+   * @param { { importer: string, isDynamic: boolean} } context
+   * @param { (specifier: string, importer: string) => string | undefined } defaultResolve
+   */
+  onResolveImport(specifier, context, defaultResolve) {
+    return `dynamicImport('/some-path-prefix/${specifier}.js', '${context.importer}')`;
+  },
+
+  /**
    * Modify response body before sending to the browser.
    * This hook is run after all modifications by dvlp, and before sending to the browser.
    *
@@ -129,7 +144,7 @@ module.exports = {
    */
   onSend(filePath, responseBody) {
     if (RE_JS.test(filePath)) {
-      return responseBody.replace(/import\(/g, 'dynamicImportPolyfill(');
+      return responseBody.replace('__VERSION__', '1.0.0');
     }
   },
 };

--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ module.exports = {
    * @param { (specifier: string, importer: string) => string | undefined } defaultResolve
    */
   onResolveImport(specifier, context, defaultResolve) {
-    return `dynamicImport('/some-path-prefix/${specifier}.js', '${context.importer}')`;
+    if (context.isDynamic) {
+      return `dynamicImport('./some-path-prefix/${specifier}.js', '${context.importer}')`;
+    }
   },
 
   /**

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -121,6 +121,7 @@ module.exports = class DvlpServer {
         string: headerScript,
       },
       rollupConfigPath,
+      resolveHook: this.hooks.resolveImport,
       sendHook: this.hooks.send,
     };
   }

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -332,6 +332,7 @@ module.exports = class DvlpServer {
         filePath = find(req, { type });
 
         if (filePath) {
+          server.addWatchFiles(filePath);
           server.urlToFilePath.set(req.url, filePath);
 
           if (isModuleBundlerFilePath(filePath)) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -130,7 +130,12 @@ declare type PatchResponseOptions = {
     string: string;
     url?: string;
   };
-  sendHook?: (filePath: string, code: string) => string | undefined;
+  sendHook?: (filePath: string, fileContents: string) => string | undefined;
+  resolveHook?: (
+    specifier: string,
+    context: HookContext,
+    defaultResolve: DefaultResolve,
+  ) => string | false | undefined;
   rollupConfigPath?: string;
 };
 
@@ -139,13 +144,14 @@ declare type FindOptions = {
   type?: string;
 };
 
-declare type Hooks = {
-  onTransform(
-    filePath: string,
-    fileContents: string,
-  ): Promise<string> | string | undefined;
-  onSend(filePath: string, responseBody: string): string | undefined;
-  onServerTransform(filePath: string, fileContents: string): string | undefined;
+declare type DefaultResolve = (
+  specifier: string,
+  importer: string,
+) => string | undefined;
+
+declare type HookContext = {
+  importer: string;
+  isDynamic: boolean;
 };
 
 declare type Transpiler = (
@@ -154,12 +160,6 @@ declare type Transpiler = (
 ) => Promise<string> | string | undefined;
 
 declare type TranspilerCache = Map<string, string>;
-
-declare type TranspilerState = {
-  transpilerCache: TranspilerCache;
-  lastChanged: string;
-  transpiler: Transpiler;
-};
 
 declare type Watcher = {
   add: (filePath: string) => void;
@@ -289,6 +289,64 @@ declare class Mock {
 declare type MockResponseJSONSchema = {
   request: MockRequest;
   response: MockResponse;
+};
+
+declare class TestServer {
+  latency: number;
+  port: number;
+  mocks: Mock;
+  webroot: string;
+
+  constructor(options?: TestServerOptions);
+  /**
+   * Load mock files at `filePath`
+   */
+  loadMockFiles(filePath: string | Array<string>): void;
+  /**
+   * Register mock `response` for `request`.
+   * If `once`, mock will be unregistered after first use.
+   * If `onMock`, callback when response is mocked
+   */
+  mockResponse(
+    request: string | MockRequest,
+    response: MockResponse | MockResponseHandler,
+    once?: boolean,
+    onMockCallback?: () => void,
+  ): void;
+  /**
+   * Register mock push `events` for `stream`
+   */
+  mockPushEvents(
+    stream: string | MockPushStream,
+    events: MockPushEvent | Array<MockPushEvent>,
+  ): void;
+  /**
+   * Push data to WebSocket/EventSource clients
+   * A string passed as `event` will be handled as a named mock push event
+   */
+  pushEvent(stream: string | PushStream, event?: string | PushEvent): void;
+  /**
+   * Clear all mock data
+   */
+  clearMockFiles(): void;
+  /**
+   * Destroy server instance
+   */
+  destroy(): Promise<void>;
+}
+
+/* export */ declare type Hooks = {
+  onTransform(
+    filePath: string,
+    fileContents: string,
+  ): Promise<string> | string | undefined;
+  onImportResolve(
+    specifier: string,
+    context: HookContext,
+    defaultResolve: DefaultResolve,
+  ): string | false | undefined;
+  onSend(filePath: string, responseBody: string): string | undefined;
+  onServerTransform(filePath: string, fileContents: string): string | undefined;
 };
 
 /* export */ declare type MockRequest = {
@@ -431,50 +489,6 @@ declare interface PushClient {
    */
   webroot?: string;
 };
-
-declare class TestServer {
-  latency: number;
-  port: number;
-  mocks: Mock;
-  webroot: string;
-
-  constructor(options?: TestServerOptions);
-  /**
-   * Load mock files at `filePath`
-   */
-  loadMockFiles(filePath: string | Array<string>): void;
-  /**
-   * Register mock `response` for `request`.
-   * If `once`, mock will be unregistered after first use.
-   * If `onMock`, callback when response is mocked
-   */
-  mockResponse(
-    request: string | MockRequest,
-    response: MockResponse | MockResponseHandler,
-    once?: boolean,
-    onMockCallback?: () => void,
-  ): void;
-  /**
-   * Register mock push `events` for `stream`
-   */
-  mockPushEvents(
-    stream: string | MockPushStream,
-    events: MockPushEvent | Array<MockPushEvent>,
-  ): void;
-  /**
-   * Push data to WebSocket/EventSource clients
-   * A string passed as `event` will be handled as a named mock push event
-   */
-  pushEvent(stream: string | PushStream, event?: string | PushEvent): void;
-  /**
-   * Clear all mock data
-   */
-  clearMockFiles(): void;
-  /**
-   * Destroy server instance
-   */
-  destroy(): Promise<void>;
-}
 
 /* export */ declare function testServer(
   options: TestServerOptions,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -340,7 +340,7 @@ declare class TestServer {
     filePath: string,
     fileContents: string,
   ): Promise<string> | string | undefined;
-  onImportResolve(
+  onResolveImport(
     specifier: string,
     context: HookContext,
     defaultResolve: DefaultResolve,

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -25,6 +25,9 @@ module.exports = class Hooker {
       if (module.onTransform) {
         this._onTransform = module.onTransform;
       }
+      if (module.onImportResolve) {
+        this._onImportResolve = module.onImportResolve;
+      }
       if (module.onSend) {
         this._onSend = module.onSend;
       }
@@ -65,6 +68,7 @@ module.exports = class Hooker {
     /** @type { Map<string, string> } */
     this.transformCache = new Map();
     this.transform = this.transform.bind(this);
+    this.resolveImport = this.resolveImport.bind(this);
     this.send = this.send.bind(this);
     this.serverTransform = this.serverTransform.bind(this);
   }
@@ -130,6 +134,17 @@ module.exports = class Hooker {
   }
 
   /**
+   * Resolve module import specifier
+   *
+   * @param { string } specifier
+   * @param { HookContext } context
+   * @param { DefaultResolve } defaultResolve
+   */
+  resolveImport(specifier, context, defaultResolve) {
+    return this._onImportResolve(specifier, context, defaultResolve);
+  }
+
+  /**
    * Allow modification of 'filePath' content before sending the request
    *
    * @param { string } filePath
@@ -152,7 +167,7 @@ module.exports = class Hooker {
 
   /**
    * Transform file contents hook.
-   * Return new file contents or `undefined` if no change.
+   * Return new file contents or "undefined" if no change.
    *
    * @param { string } filePath
    * @param { string } fileContents
@@ -163,8 +178,23 @@ module.exports = class Hooker {
   }
 
   /**
+   * Resolve import specifier hook.
+   * Return new specifier, "false" to ignore resolving, or "undefined" if relying on default behaviour.
+   * When "context.isDynamic", the returned value may include surrounding context:
+   * "dynamicImport('resolved-path-to-module', 'parent-path')".
+   *
+   * @param { string } specifier
+   * @param { HookContext } context
+   * @param { DefaultResolve } defaultResolve
+   * @returns { string | false | undefined }
+   */
+  _onImportResolve(specifier, context, defaultResolve) {
+    return;
+  }
+
+  /**
    * Send file response hook.
-   * Return new response body or `undefined` if no change.
+   * Return new response body or "undefined" if no change.
    *
    * @param { string } filePath
    * @param { string } responseBody
@@ -176,7 +206,7 @@ module.exports = class Hooker {
 
   /**
    * Transform file contents hook for server import/require.
-   * Return new file contents or `undefined` if no change.
+   * Return new file contents or "undefined" if no change.
    *
    * @param { string } filePath
    * @param { string } fileContents

--- a/src/utils/patch.js
+++ b/src/utils/patch.js
@@ -18,6 +18,7 @@ const {
 const { warn, WARN_BARE_IMPORT } = require('./log.js');
 const config = require('../config.js');
 const debug = require('debug')('dvlp:patch');
+const { existsSync } = require('fs');
 const { filePathToUrl } = require('./url.js');
 const { isModule } = require('./module.js');
 const Metrics = require('./metrics.js');
@@ -26,6 +27,7 @@ const { parse } = require('es-module-lexer');
 const { resolve } = require('../resolver/index.js');
 
 const RE_CLOSE_BODY_TAG = /<\/body>/i;
+const RE_DYNAMIC_IMPORT = /(^[^(]+\(['"])([^'"]+)(['"][^)]+\))/;
 const RE_NONCE_SHA = /nonce-|sha\d{3}-/;
 const RE_OPEN_HEAD_TAG = /<head>/i;
 
@@ -47,7 +49,7 @@ function patchResponse(
   filePath,
   req,
   res,
-  { footerScript, headerScript, rollupConfigPath, sendHook } = {
+  { footerScript, headerScript, rollupConfigPath, resolveHook, sendHook } = {
     rollupConfigPath: '',
   },
 ) {
@@ -121,7 +123,7 @@ function patchResponse(
       enableCrossOriginHeader(res);
       // @ts-ignore
       disableCacheControlHeader(res, req.url);
-      code = rewriteImports(res, filePath, rollupConfigPath, code);
+      code = rewriteImports(res, filePath, rollupConfigPath, code, resolveHook);
 
       if (sendHook) {
         const transformed = sendHook(filePath, code);
@@ -274,9 +276,10 @@ function injectCSPHeader(res, urls, hashes, key, value) {
  * @param { string } filePath
  * @param { string | undefined } rollupConfigPath
  * @param { string } code
+ * @param { PatchResponseOptions["resolveHook"] } resolveHook
  * @returns { string }
  */
-function rewriteImports(res, filePath, rollupConfigPath, code) {
+function rewriteImports(res, filePath, rollupConfigPath, code, resolveHook) {
   res.metrics.recordEvent('rewrite JS imports');
 
   // Retrieve original source path from bundled file
@@ -287,6 +290,7 @@ function rewriteImports(res, filePath, rollupConfigPath, code) {
 
   try {
     const projectFilePath = getProjectPath(filePath);
+    const importer = getAbsoluteProjectPath(filePath);
     const [imports] = parse(code);
 
     if (imports.length > 0) {
@@ -298,12 +302,15 @@ function rewriteImports(res, filePath, rollupConfigPath, code) {
         const isDynamic = d > -1;
         let start = offset + s;
         let end = offset + e;
-        let id = code.substring(start, end);
+        let specifier = code.substring(start, end);
+        let after = '';
+        let before = '';
+        let importPath;
 
         if (isDynamic) {
           // Dynamic import indexes include quotes if strings, so strip from id before resolving
-          if (/^['"]/.test(id)) {
-            id = id.slice(1, -1);
+          if (/^['"]/.test(specifier)) {
+            specifier = specifier.slice(1, -1);
             start++;
             end--;
           } else {
@@ -312,42 +319,79 @@ function rewriteImports(res, filePath, rollupConfigPath, code) {
           }
         }
 
-        const importPath = resolve(id, getAbsoluteProjectPath(filePath));
+        if (resolveHook) {
+          const hookResult = resolveHook(
+            specifier,
+            {
+              isDynamic,
+              importer,
+            },
+            resolve,
+          );
 
-        if (importPath) {
+          if (hookResult === false) {
+            // Force ignored by hook
+            continue;
+          } else if (hookResult !== undefined) {
+            // Handle import statement substitution
+            if (isDynamic && hookResult.includes('(')) {
+              const match = hookResult.match(RE_DYNAMIC_IMPORT);
+              if (match) {
+                [, before, importPath, after] = match;
+                start -= 8;
+                end += 2;
+              } else {
+                // Error parsing substitution;
+                continue;
+              }
+            } else {
+              importPath = hookResult;
+              importPath = path.resolve(importPath);
+            }
+          }
+        } else {
+          importPath = resolve(specifier, importer);
+        }
+
+        if (importPath && existsSync(importPath)) {
           let newId = '';
 
           // Bundle if in node_modules and not an es module
           if (isNodeModuleFilePath(importPath) && !isModule(importPath)) {
-            const resolvedId = resolveModuleId(id, importPath);
+            const resolvedId = resolveModuleId(specifier, importPath);
 
             // Trigger bundling in background while waiting for eventual request
-            bundle(resolvedId, rollupConfigPath, id, importPath);
+            bundle(resolvedId, rollupConfigPath, specifier, importPath);
             newId = `/${path.join(config.bundleDirName, resolvedId)}`;
-            warn(WARN_BARE_IMPORT, id);
+            warn(WARN_BARE_IMPORT, specifier);
           } else {
             // Don't rewrite if no change after resolving
             newId =
-              isRelativeFilePath(id) &&
-              path.join(path.dirname(filePath), id) === importPath
-                ? id
+              isRelativeFilePath(specifier) &&
+              path.join(path.dirname(filePath), specifier) === importPath
+                ? specifier
                 : importPath;
           }
 
           newId = filePathToUrl(newId);
 
-          if (newId !== id) {
+          if (newId !== specifier) {
             debug(
               `rewrote ${
                 isDynamic ? 'dynamic' : ''
-              } import id from "${id}" to "${newId}"`,
+              } import id from "${specifier}" to "${newId}"`,
             );
-            code = code.substring(0, start) + newId + code.substring(end);
-            offset += newId.length - id.length;
+            code =
+              code.substring(0, start) +
+              before +
+              newId +
+              after +
+              code.substring(end);
+            offset += newId.length - specifier.length;
           }
         } else {
           warn(
-            `⚠️  unable to resolve path for "${id}" from "${projectFilePath}"`,
+            `⚠️  unable to resolve path for "${specifier}" from "${projectFilePath}"`,
           );
         }
       }

--- a/src/utils/patch.js
+++ b/src/utils/patch.js
@@ -18,7 +18,6 @@ const {
 const { warn, WARN_BARE_IMPORT } = require('./log.js');
 const config = require('../config.js');
 const debug = require('debug')('dvlp:patch');
-const { existsSync } = require('fs');
 const { filePathToUrl } = require('./url.js');
 const { isModule } = require('./module.js');
 const Metrics = require('./metrics.js');
@@ -345,15 +344,16 @@ function rewriteImports(res, filePath, rollupConfigPath, code, resolveHook) {
                 continue;
               }
             } else {
-              importPath = hookResult;
-              importPath = path.resolve(importPath);
+              importPath = path.resolve(hookResult);
             }
           }
-        } else {
+        }
+
+        if (!importPath) {
           importPath = resolve(specifier, importer);
         }
 
-        if (importPath && existsSync(importPath)) {
+        if (importPath) {
           let newId = '';
 
           // Bundle if in node_modules and not an es module


### PR DESCRIPTION
Adds hook for manipulating import specifiers, as well as allowing replacement of dynamic import expressions for implementing `import(...)` polyfills:

```js
onResolveImport: (specifier, context, defaultResolve) => {
  return `dynamicImport('/some-path-prefix/${specifier}.js', '${context.importer}')`;
},
```