### PR TITLE
Add glob support to --ssl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Options:
   -p, --port <port>           port number
   -m, --mock <path>           path to mock files (directory, file, glob pattern)
   -k, --hooks <path>          path to optional hooks registration file
-  --ssl <path>                enable https mode by specifying path to directory
-                              containing ".crt" and ".key" files
+  --ssl <path>                enable https mode by specifying path to
+                              ".crt"  and ".key" files (directory, glob pattern)
   -r, --rollup-config <path>  path to optional Rollup.js config file
   -s, --silent                suppress default logging
   --no-reload                 disable reloading connected browsers on file change
@@ -484,7 +484,7 @@ All supported options are listed in the Rollup.js [documentation](https://rollup
 
 ### SSL
 
-Enable development against a secure server by passing the path to a directory containing your `.crt` and `.key` files with the `--ssl` option.
+Enable development against a secure server by passing the path or glob pattern to your `.crt` and `.key` files with the `--ssl` option.
 
 > Follow the directions [here](https://deliciousbrains.com/ssl-certificate-authority-for-local-https-development/) to generate a self-signed certificate for local development
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Options:
   -m, --mock <path>           path to mock files (directory, file, glob pattern)
   -k, --hooks <path>          path to optional hooks registration file
   --ssl <path>                enable https mode by specifying path to
-                              ".crt"  and ".key" files (directory, glob pattern)
+                              ".crt" and ".key" files (directory, glob pattern)
   -r, --rollup-config <path>  path to optional Rollup.js config file
   -s, --silent                suppress default logging
   --no-reload                 disable reloading connected browsers on file change

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -37,6 +37,10 @@ module.exports = async function serverFactory(
 
   config.directories = Array.from(new Set(entry.directories));
 
+  if (certsPath) {
+    certsPath = expandPath(certsPath);
+  }
+
   if (mockPath) {
     mockPath = expandPath(mockPath);
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -445,10 +445,10 @@ declare interface PushClient {
 
 /* export */ declare type ServerOptions = {
   /**
-   * The path to a directory containing ".crt" and ".key" files.
+   * The path or glob pattern containing ".crt" and ".key" files.
    * This enables secure https mode by proxying all requests through a secure server (default `''`).
    */
-  certsPath?: string;
+  certsPath?: string | Array<string>;
   /**
    * The path to a custom hooks registration file (default `''`).
    */

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -34,6 +34,7 @@ module.exports = {
   getProjectPath,
   getTypeFromPath,
   getTypeFromRequest,
+  getDirectoryContents,
   resolveRealFilePath,
   resolveNodeModulesDirectories,
 };
@@ -222,6 +223,22 @@ function getTypeFromRequest(req) {
  */
 function getTypeFromPath(filePath) {
   return config.typesByExtension[path.extname(filePath)];
+}
+
+/**
+ * Get directory contents of path
+ *
+ * @param { string } dirPath
+ * @returns { Array<string> }
+ */
+function getDirectoryContents(dirPath) {
+  if (fs.statSync(dirPath).isFile()) {
+    return [dirPath];
+  }
+
+  return fs
+    .readdirSync(dirPath)
+    .map((filePath) => path.resolve(dirPath, filePath));
 }
 
 /**

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -635,6 +635,16 @@ describe('server', () => {
           expect(res.status).to.eql(200);
           expect(await res.text()).to.contain('<!doctype html>');
         });
+        it('should locate .crt and .key files when passed globs', async () => {
+          server = await serverFactory('test/fixtures/www', {
+            certsPath: 'test/fixtures/certificates/dvlp.*',
+            port: 8000,
+            reload: false,
+          });
+          const res = await fetch('https://localhost:443/');
+          expect(res.status).to.eql(200);
+          expect(await res.text()).to.contain('<!doctype html>');
+        });
         it('should serve a js file with correct mime type over https', async () => {
           server = await serverFactory('test/fixtures/www', {
             certsPath: 'test/fixtures/certificates',


### PR DESCRIPTION
When generating multiple certificates using Let's Encrypt  the `.lego` directory will contain multiple `.crt/.key` pairs. This adds glob support to `--ssl`