### PR TITLE
fix mock headers merging

### DIFF
--- a/test/fixtures/mock/5678.json
+++ b/test/fixtures/mock/5678.json
@@ -5,7 +5,8 @@
   },
   "response": {
     "headers": {
-      "x-custom": "custom header"
+      "x-custom": "custom header",
+      "date": "Fri, 13 Oct 2020 23:59:59 GMT"
     },
     "body": {
       "user": {

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -248,6 +248,7 @@ describe('mock', () => {
       expect(res.body).to.equal('{"user":{"name":"Nancy","id":5678}}');
       expect(res.headers['Content-Type']).to.equal('application/json');
       expect(res.headers['x-custom']).to.equal('custom header');
+      expect(res.headers['Date']).to.equal('Fri, 13 Oct 2020 23:59:59 GMT');
       expect(res.headers['Access-Control-Allow-Origin']).to.equal('*');
     });
     it('should respond to request for mock json with search params', () => {


### PR DESCRIPTION
Allow mock `Date` header to be overwritten (breaking change), and ensure that `Date` and `Content-Type` headers can be overwritten when lowercase.

see #356 