### PR TITLE
make start timeout consider last file intercept

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -181,7 +181,7 @@ module.exports = class DvlpServer {
         if (didTimeout) {
           clearInterval(timeoutIntervalID);
           debug('server not started after timeout');
-          reject(Error('unable to start server'));
+          reject(Error(`unable to start server: application server did not respond within the ${START_TIMEOUT_DURATION}ms startup window`));
         }
       }, 1000);
       const instance = this;


### PR DESCRIPTION
A slow machine combined with a large project (many watched files) can result in very slow startup times (my project is  ~7 seconds)

This PR makes the timeout be based on `lastInterceptFileRead`