### PR TITLE
add `onRequest` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ module.exports = {
   },
 
   /**
+   * Manually handle response for incoming server request.
+   * If returns "true", further processing by dvlp will be aborted.
+   *
+   * @param { IncomingMessage | Http2ServerRequest } request
+   * @param { ServerResponse | Http2ServerResponse } response
+   * @returns { Promise<boolean> | boolean | undefined }
+   */
+  onRequest(request, response) {
+    if (request.url === '/something') {
+      response.writeHead(200);
+      response.end('handled');
+      return true;
+    }
+  },
+
+  /**
    * Modify response body before sending to the browser.
    * This hook is run after all modifications by dvlp, and before sending to the browser.
    *

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "node-fetch": "^2.6.0",
         "path-to-regexp": "^6.2.0",
         "permessage-deflate": "^0.1.7",
-        "pirates": "^4.0.1",
         "platform": "^1.3.6",
         "prettier": "^2.2.0",
         "react": "^17.0.0",
@@ -2754,15 +2753,6 @@
         "node": "4.x || >=6.0.0"
       }
     },
-    "node_modules/node-modules-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/node-releases": {
       "version": "1.1.72",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
@@ -3069,18 +3059,6 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
       "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==",
       "dev": true
-    },
-    "node_modules/pirates": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
-      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
-      "dev": true,
-      "dependencies": {
-        "node-modules-regexp": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/platform": {
       "version": "1.3.6",
@@ -6387,12 +6365,6 @@
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
-    "node-modules-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
-      "dev": true
-    },
     "node-releases": {
       "version": "1.1.72",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
@@ -6620,15 +6592,6 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
       "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==",
       "dev": true
-    },
-    "pirates": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
-      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
-      "dev": true,
-      "requires": {
-        "node-modules-regexp": "^1.0.0"
-      }
     },
     "platform": {
       "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "node-fetch": "^2.6.0",
     "path-to-regexp": "^6.2.0",
     "permessage-deflate": "^0.1.7",
-    "pirates": "^4.0.1",
     "platform": "^1.3.6",
     "prettier": "^2.2.0",
     "react": "^17.0.0",

--- a/src/_dvlp.d.ts
+++ b/src/_dvlp.d.ts
@@ -290,23 +290,54 @@ interface ResolveHookContext {
 type DefaultResolve = (specifier: string, importer: string) => string | undefined;
 
 export interface Hooks {
+  /**
+   * Bundle non-esm node_modules dependency requested by the browser.
+   * This hook is run after file read.
+   */
   onDependencyBundle?(
     id: string,
     filePath: string,
     fileContents: string,
     context: DependencyBundleHookContext,
   ): Promise<string> | string | undefined;
+  /**
+   * Transform file contents for file requested by the browser.
+   * This hook is run after file read, and before any modifications by dvlp.
+   */
   onTransform?(
     filePath: string,
     fileContents: string,
     context: TransformHookContext,
   ): Promise<string> | string | undefined;
+  /**
+   * Manually resolve import specifier.
+   * This hook is run for each import statement.
+   * If returns "false", import re-writing is skipped.
+   * If returns "undefined", import specifier is re-written using default resolver.
+   * If "context.isDynamic", also possible to return replacement for whole expression.
+   */
   onResolveImport?(
     specifier: string,
     context: ResolveHookContext,
     defaultResolve: DefaultResolve,
   ): string | false | undefined;
+  /**
+   * Manually handle response for incoming server request.
+   * If returns "true", further processing by dvlp will be aborted.
+   */
+  onRequest?(
+    request: IncomingMessage | Http2ServerRequest,
+    response: ServerResponse | Http2ServerResponse,
+  ): Promise<boolean> | boolean | undefined;
+  /**
+   * Modify response body before sending to the browser.
+   * This hook is run after all modifications by dvlp, and before sending to the browser.
+   */
   onSend?(filePath: string, responseBody: string): string | undefined;
+  /**
+   * Transform file contents for file imported by Node.js application server.
+   * This hook is run after file read.
+   */
   onServerTransform?(filePath: string, fileContents: string): string | undefined;
 }
 

--- a/src/dvlp-browser.d.ts
+++ b/src/dvlp-browser.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="_dvlp.d.ts" />
+import { MockResponse, MockResponseHandler, PushEvent } from './_dvlp';
 
 export namespace testBrowser {
   /**
@@ -14,8 +14,8 @@ export namespace testBrowser {
    * Add mock response for "req"
    */
   function mockResponse(
-    req: string | _dvlp.MockRequest,
-    res?: _dvlp.MockResponse | _dvlp.MockResponseHandler,
+    req: string | MockRequest,
+    res?: MockResponse | MockResponseHandler,
     once?: boolean,
     onMockCallback?: () => void,
   ): () => void;
@@ -23,7 +23,7 @@ export namespace testBrowser {
    * Push data to WebSocket/EventSource clients
    * A string passed as `event` will be handled as a named mock push event
    */
-  function pushEvent(stream: string, event?: string | _dvlp.PushEvent): void;
+  function pushEvent(stream: string, event?: string | PushEvent): void;
 }
 
 declare global {

--- a/src/dvlp.d.ts
+++ b/src/dvlp.d.ts
@@ -1,11 +1,10 @@
-/// <reference path="_dvlp.d.ts" />
+import { Hooks, Req, Res, Server, ServerOptions, TestServer, TestServerOptions } from './_dvlp';
 
-export function server(
-  filePath: string | Array<string> | (() => void),
-  options?: _dvlp.ServerOptions,
-): Promise<_dvlp.Server>;
+export { Hooks };
 
-export function testServer(options: _dvlp.TestServerOptions): Promise<_dvlp.TestServer>;
+export function server(filePath: string | Array<string> | (() => void), options?: ServerOptions): Promise<Server>;
+
+export function testServer(options: TestServerOptions): Promise<TestServer>;
 
 export namespace testServer {
   /**
@@ -20,17 +19,17 @@ export namespace testServer {
   /**
    * Default mock response handler for network hang
    */
-  function mockHangResponseHandler(url: URL, req: _dvlp.Req, res: _dvlp.Res): undefined;
+  function mockHangResponseHandler(url: URL, req: Req, res: Res): undefined;
   /**
    * Default mock response handler for 500 response
    */
-  function mockErrorResponseHandler(url: URL, req: _dvlp.Req, res: _dvlp.Res): undefined;
+  function mockErrorResponseHandler(url: URL, req: Req, res: Res): undefined;
   /**
    * Default mock response handler for 404 response
    */
-  function mockMissingResponseHandler(url: URL, req: _dvlp.Req, res: _dvlp.Res): undefined;
+  function mockMissingResponseHandler(url: URL, req: Req, res: Res): undefined;
   /**
    * Default mock response handler for offline
    */
-  function mockOfflineResponseHandler(url: URL, req: _dvlp.Req, res: _dvlp.Res): undefined;
+  function mockOfflineResponseHandler(url: URL, req: Req, res: Res): undefined;
 }

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -214,7 +214,7 @@ export default class Hooker {
           result = code;
         }
       } catch (err) {
-        console.log(err);
+        error(err);
       }
     }
 

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,3 +1,4 @@
+import { error, warn } from '../utils/log.js';
 import { getProjectPath, isCjsFile } from '../utils/file.js';
 import { isNodeModuleFilePath, isProjectFilePath } from '../utils/is.js';
 import bundleDependency from './bundle-dependency.js';
@@ -6,10 +7,9 @@ import esbuild from 'esbuild';
 import path from 'path';
 import { resolve } from '../resolver/index.js';
 import transform from './transform.js';
-import { warn } from '../utils/log.js';
 import { writeFileSync } from 'fs';
 
-const HOOK_NAMES = ['onDependencyBundle', 'onTransform', 'onResolveImport', 'onSend', 'onServerTransform'];
+const HOOK_NAMES = ['onDependencyBundle', 'onTransform', 'onResolveImport', 'onRequest', 'onSend', 'onServerTransform'];
 
 export default class Hooker {
   /**
@@ -136,6 +136,31 @@ export default class Hooker {
   }
 
   /**
+   * Allow external response handling
+   *
+   * @param { _dvlp.Req } req
+   * @param { _dvlp.Res } res
+   * @returns { Promise<boolean> }
+   */
+  async handleRequest(req, res) {
+    if (this.hooks && this.hooks.onRequest) {
+      try {
+        // Check if finished in case no return value
+        if ((await this.hooks.onRequest(req, res)) || res.finished) {
+          return true;
+        }
+      } catch (err) {
+        res.writeHead(500);
+        res.end(err.message);
+        error(err);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * Allow modification of 'filePath' content before sending the request
    *
    * @param { string } filePath
@@ -167,25 +192,29 @@ export default class Hooker {
     }
     if (result === undefined && !isCjsFile(filePath, fileContents)) {
       const sourcemap = isProjectFilePath(filePath);
-      const { code, map } = esbuild.transformSync(fileContents, {
-        format: 'cjs',
-        // @ts-ignore
-        loader: config.esbuildTargetByExtension[path.extname(filePath)] || 'default',
-        sourcesContent: false,
-        sourcefile: filePath,
-        sourcemap,
-        sourceRoot: config.sourceMapsDir,
-        target: `node${process.versions.node}`,
-      });
+      try {
+        const { code, map } = esbuild.transformSync(fileContents, {
+          format: 'cjs',
+          // @ts-ignore
+          loader: config.esbuildTargetByExtension[path.extname(filePath)] || 'default',
+          sourcesContent: false,
+          sourcefile: filePath,
+          sourcemap,
+          sourceRoot: config.sourceMapsDir,
+          target: `node${process.versions.node}`,
+        });
 
-      if (sourcemap) {
-        const sourceMapPath =
-          path.resolve(config.sourceMapsDir, getProjectPath(filePath).replace(/\/|\\/g, '_')) + '.map';
+        if (sourcemap) {
+          const sourceMapPath =
+            path.resolve(config.sourceMapsDir, getProjectPath(filePath).replace(/\/|\\/g, '_')) + '.map';
 
-        writeFileSync(sourceMapPath, map);
-        result = code + `//# sourceMappingURL=${sourceMapPath}`;
-      } else {
-        result = code;
+          writeFileSync(sourceMapPath, map);
+          result = code + `//# sourceMappingURL=${sourceMapPath}`;
+        } else {
+          result = code;
+        }
+      } catch (err) {
+        console.log(err);
       }
     }
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -286,6 +286,11 @@ export default class DvlpServer {
         return;
       }
 
+      // Allow manual response handling via user hook
+      if (await server.hooks.handleRequest(req, res)) {
+        return;
+      }
+
       // Ignore html or uncached or no longer available at previously known path
       if (type !== 'html' && (!filePath || !fs.existsSync(filePath))) {
         filePath = find(req, { type });

--- a/test/unit/fixtures/hooks-request.mjs
+++ b/test/unit/fixtures/hooks-request.mjs
@@ -1,0 +1,9 @@
+export default {
+  onRequest(req, res) {
+    if (req.url === '/api') {
+      res.writeHead(200);
+      res.end('handled');
+      return true;
+    }
+  },
+};

--- a/test/unit/server-test.js
+++ b/test/unit/server-test.js
@@ -156,6 +156,18 @@ describe('server', () => {
       expect(res.status).to.eql(200);
       expect(await res.text()).to.contain('this is sent content for: style.css');
     });
+    it('should handle request when using an onRequest hook', async () => {
+      server = await serverFactory('test/unit/fixtures/www', {
+        port: 8100,
+        reload: false,
+        hooksPath: 'test/unit/fixtures/hooks-request.mjs',
+      });
+      let res = await fetch('http://localhost:8100/favicon.ico');
+      expect(res.headers.get('content-type')).to.include('image/x-icon');
+      res = await fetch('http://localhost:8100/api');
+      expect(res.status).to.eql(200);
+      expect(await res.text()).to.contain('handled');
+    });
     it('should cache transformed file content when using an onTransform hook', async () => {
       server = await serverFactory('test/unit/fixtures/www', {
         port: 8100,


### PR DESCRIPTION
Adds an `onRequest(req, res)` hook to inject middleware/request handlers into the request/response flow. This enables custom dev-only request processing:

```js
/**
 * @type { import('dvlp').Hooks }
 */
export default {
  onRequest(req, res) {
    if (req.url.startsWith('/api/')) {
      somApiProxyHandler(req, res);
      return true;
    }
  },
};
```

Also fixes an error when importing application files ending in `.js` from an esm project (`package.json#type === 'module'`). The native Node js loader is avoided here by replacing `pirates.addHook` with a custom implementation.