### PR TITLE
fix export signature for `dvlp/test`

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -43,7 +43,6 @@ const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
   });
 
   await esbuild.build({
-    banner,
     bundle: true,
     define,
     entryPoints: ['./src/dvlp-test.js'],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -43,6 +43,7 @@ const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
   });
 
   await esbuild.build({
+    banner,
     bundle: true,
     define,
     entryPoints: ['./src/dvlp-test.js'],

--- a/src/dvlp-test.js
+++ b/src/dvlp-test.js
@@ -16,7 +16,7 @@ let uninterceptClientRequest;
  * @param { TestServerOptions } [options]
  * @returns { Promise<TestServer> }
  */
-export default async function testServerFactory(options) {
+export async function testServer(options) {
   enableRequestIntercept();
 
   const server = new TestServer(options || {});
@@ -47,7 +47,7 @@ export default async function testServerFactory(options) {
  * @param { boolean } [rerouteAllRequests]
  * @returns { void }
  */
-testServerFactory.disableNetwork = function disableNetwork(rerouteAllRequests = false) {
+testServer.disableNetwork = function disableNetwork(rerouteAllRequests = false) {
   enableRequestIntercept();
   networkDisabled = true;
   reroute = rerouteAllRequests;
@@ -58,7 +58,7 @@ testServerFactory.disableNetwork = function disableNetwork(rerouteAllRequests = 
  *
  * @returns { void }
  */
-testServerFactory.enableNetwork = function enableNetwork() {
+testServer.enableNetwork = function enableNetwork() {
   enableRequestIntercept();
   networkDisabled = false;
   reroute = false;
@@ -71,7 +71,7 @@ testServerFactory.enableNetwork = function enableNetwork() {
  * @param { Res } res
  * @returns { undefined }
  */
-testServerFactory.mockHangResponseHandler = function mockHangResponseHandler(req, res) {
+testServer.mockHangResponseHandler = function mockHangResponseHandler(req, res) {
   return;
 };
 
@@ -82,7 +82,7 @@ testServerFactory.mockHangResponseHandler = function mockHangResponseHandler(req
  * @param { Res } res
  * @returns { undefined }
  */
-testServerFactory.mockErrorResponseHandler = function mockErrorResponseHandler(req, res) {
+testServer.mockErrorResponseHandler = function mockErrorResponseHandler(req, res) {
   res.writeHead(500);
   res.error = Error('error');
   res.end('error');
@@ -96,7 +96,7 @@ testServerFactory.mockErrorResponseHandler = function mockErrorResponseHandler(r
  * @param { Res } res
  * @returns { undefined }
  */
-testServerFactory.mockMissingResponseHandler = function mockMissingResponseHandler(req, res) {
+testServer.mockMissingResponseHandler = function mockMissingResponseHandler(req, res) {
   res.writeHead(404);
   res.end('missing');
   return;
@@ -109,7 +109,7 @@ testServerFactory.mockMissingResponseHandler = function mockMissingResponseHandl
  * @param { Res } res
  * @returns { undefined }
  */
-testServerFactory.mockOfflineResponseHandler = function mockOfflineResponseHandler(req, res) {
+testServer.mockOfflineResponseHandler = function mockOfflineResponseHandler(req, res) {
   req.socket.destroy();
   return;
 };

--- a/test/integration/test-server-test.js
+++ b/test/integration/test-server-test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import fetch from 'node-fetch';
-import testServer from 'dvlp/test';
+import { testServer } from 'dvlp/test';
 
 let server;
 

--- a/test/unit/test-server-test.js
+++ b/test/unit/test-server-test.js
@@ -1,7 +1,7 @@
 import EventSource from 'eventsource';
 import { expect } from 'chai';
 import fetch from 'node-fetch';
-import testServer from '../../src/dvlp-test.js';
+import { testServer } from '../../src/dvlp-test.js';
 import websocket from 'faye-websocket';
 
 const { Client: WebSocket } = websocket;


### PR DESCRIPTION
Replaces default export with named `testServer` export to align with types. 

~Also removes unnecessary `const require = createRequire...` build time banner~ (edit: not so unnecessary)