### PR TITLE
Fix package resolving

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        node: ['14', '16', '17']
+        node: ['14']
     runs-on: ${{ matrix.os }}
     name: Install, build, and test (OS ${{ matrix.os }} - Node ${{ matrix.node }})
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   build_deploy:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
         node: ['14', '16', '17']
     runs-on: ${{ matrix.os }}
     name: Install, build, and test (OS ${{ matrix.os }} - Node ${{ matrix.node }})

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ jobs:
   build_deploy:
     strategy:
       matrix:
-        os: [windows-latest]
-        node: ['14']
+        os: [ubuntu-latest, windows-latest]
+        node: ['14', '16', '17']
     runs-on: ${{ matrix.os }}
     name: Install, build, and test (OS ${{ matrix.os }} - Node ${{ matrix.node }})
     steps:

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "lint:src": "eslint './{src,test}/**/*.js'",
     "lint:types": "tsc --noEmit --skipLibCheck --project jsconfig.json",
     "prepublishOnly": "npm run build",
-    "test": "cross-env NODE_ENV=dvlptest NODE_OPTIONS=\"--enable-source-maps --no-warnings\" NODE_TLS_REJECT_UNAUTHORIZED=\"0\" mocha test/unit/*-test.js --reporter spec --exit --timeout 10000",
+    "test": "cross-env NODE_ENV=dvlptest NODE_OPTIONS=\"--enable-source-maps --no-warnings\" NODE_TLS_REJECT_UNAUTHORIZED=\"0\" mocha test/unit/*-test.js --reporter spec --exit --bail --timeout 10000",
     "test:browser": "npm run build && ./bin/dvlp.js --mock test/browser/fixtures/mock test/browser",
     "test:integration": "npm run build && cross-env NODE_ENV=dvlptest mocha test/integration/*-test.js --reporter spec --exit --timeout 10000",
     "prepare": "husky install"

--- a/src/_.d.ts
+++ b/src/_.d.ts
@@ -17,7 +17,6 @@ declare interface Config {
   maxAge: string;
   reloadEndpoint: string;
   serverStartTimeout: number;
-  sourceMapsDir: string;
   testing: boolean;
   typesByExtension: {
     [extension: string]: 'css' | 'html' | 'js';

--- a/src/_.d.ts
+++ b/src/_.d.ts
@@ -2,11 +2,12 @@ declare interface Config {
   activePort: number;
   applicationLoaderPath: import('url').URL;
   brokenNamedExportsPackages: Record<string, Array<string>>;
-  bundleDir: string;
+  bundleDirMetaPath: string;
   bundleDirName: string;
+  bundleDirPath: string;
   defaultPort: number;
   directories: Array<string>;
-  dvlpDir: string;
+  dvlpDirPath: string;
   esbuildTargetByExtension: {
     [extension: string]: string;
   };

--- a/src/config.js
+++ b/src/config.js
@@ -17,8 +17,6 @@ const VERSION = global.$VERSION || 'dev';
 
 const dir = path.resolve(DIR);
 const applicationLoaderPath = pathToFileURL(path.join(dir, 'app-loader.mjs'));
-const sourceMapsDirName = `${path.join(DIR, `sourcemaps`)}`;
-const sourceMapsDir = path.resolve(sourceMapsDirName);
 const bundleDirName = `${path.join(DIR, `bundle-${VERSION}`)}`;
 const bundleDir = path.resolve(bundleDirName);
 const defaultPort = process.env.PORT ? Number(process.env.PORT) : 8080;
@@ -31,10 +29,8 @@ send.mime.define(JS_MIME_TYPES, true);
  * Create directory structure:
  *  .dvlp
  *    - bundle-xxx
- *    - sourcemaps
  */
 if (isMainThread) {
-  const sourceMapsDirExists = fs.existsSync(sourceMapsDir);
   const bundleDirExists = fs.existsSync(bundleDir);
   const dirExists = fs.existsSync(dir);
 
@@ -48,13 +44,9 @@ if (isMainThread) {
       }
     }
   }
-  if (sourceMapsDirExists) {
-    rimraf.sync(sourceMapsDir);
-  }
   if (!dirExists) {
     fs.mkdirSync(dir);
   }
-  fs.mkdirSync(sourceMapsDir);
   if (!bundleDirExists) {
     fs.mkdirSync(bundleDir);
   } else {
@@ -115,7 +107,6 @@ const config = {
   maxAge: '10m',
   reloadEndpoint: '/dvlpreload',
   serverStartTimeout: TESTING ? 4000 : 10000,
-  sourceMapsDir,
   testing: TESTING,
   typesByExtension: {
     '.css': 'css',

--- a/src/config.js
+++ b/src/config.js
@@ -7,18 +7,20 @@ import { pathToFileURL } from 'url';
 import rimraf from 'rimraf';
 import send from 'send';
 
-const DIR = '.dvlp';
+const DIR_NAME = '.dvlp';
 const JS_MIME_TYPES = {
   'application/javascript': ['js', 'mjs', 'cjs', 'jsx', 'ts', 'tsx'],
 };
 const TESTING = process.env.NODE_ENV === 'dvlptest' || process.env.CI != undefined;
 // @ts-ignore - Replaced during build
-const VERSION = global.$VERSION || 'dev';
+const VERSION = global.$VERSION || '0.0.0';
 
-const dir = path.resolve(DIR);
-const applicationLoaderPath = pathToFileURL(path.join(dir, 'app-loader.mjs'));
-const bundleDirName = `${path.join(DIR, `bundle-${VERSION}`)}`;
-const bundleDir = path.resolve(bundleDirName);
+const dirPath = path.resolve(DIR_NAME);
+const subdirPath = path.join(dirPath, VERSION);
+const applicationLoaderPath = pathToFileURL(path.join(subdirPath, 'app-loader.mjs'));
+const bundleDirName = path.join(DIR_NAME, VERSION, 'bundled');
+const bundleDirPath = path.resolve(bundleDirName);
+const bundleDirMetaPath = path.join(bundleDirPath, '__meta__.json');
 const defaultPort = process.env.PORT ? Number(process.env.PORT) : 8080;
 
 mime.define(JS_MIME_TYPES, true);
@@ -27,51 +29,30 @@ send.mime.define(JS_MIME_TYPES, true);
 
 /**
  * Create directory structure:
- *  .dvlp
- *    - bundle-xxx
+ *  .dvlp/
+ *    - <version>/
+ *      - bundled/
+ *      - app-loader.mjs
+ *      - cache.json
  */
 if (isMainThread) {
-  const bundleDirExists = fs.existsSync(bundleDir);
-  const dirExists = fs.existsSync(dir);
+  const bundleDirExists = fs.existsSync(bundleDirPath);
+  const dirExists = fs.existsSync(dirPath);
+  const subdirExists = fs.existsSync(subdirPath);
 
-  if (dirExists && !bundleDirExists) {
-    const contents = fs.readdirSync(dir).map((item) => path.resolve(dir, item));
-
-    for (const item of contents) {
-      // Delete all subdirectories
-      if (fs.statSync(item).isDirectory()) {
-        rimraf.sync(item);
-      }
+  // New version of .dvlp, so delete existing
+  if (dirExists && !subdirExists) {
+    for (const item of fs.readdirSync(dirPath)) {
+      rimraf.sync(path.resolve(dirPath, item));
     }
-  }
-  if (!dirExists) {
-    fs.mkdirSync(dir);
   }
   if (!bundleDirExists) {
-    fs.mkdirSync(bundleDir);
-  } else {
-    // Prune bundle dir of duplicates with different versions
-    const moduleIds = new Map();
-
-    for (const fileName of fs.readdirSync(bundleDir)) {
-      if (fileName.endsWith('.js')) {
-        // Remove version
-        const moduleId = fileName.slice(0, fileName.lastIndexOf('-'));
-
-        if (!moduleIds.has(moduleId)) {
-          moduleIds.set(moduleId, path.join(bundleDir, fileName));
-        } else {
-          // Clear both instances if duplicates with different versions
-          fs.unlinkSync(moduleIds.get(moduleId));
-          fs.unlinkSync(path.join(bundleDir, fileName));
-        }
-      }
-    }
+    fs.mkdirSync(bundleDirPath, { recursive: true });
   }
 
   if (TESTING) {
     process.on('exit', () => {
-      rimraf.sync(dir);
+      rimraf.sync(dirPath);
     });
   }
 }
@@ -83,11 +64,12 @@ const config = {
   activePort: defaultPort,
   applicationLoaderPath,
   brokenNamedExportsPackages,
-  bundleDir,
+  bundleDirPath,
+  bundleDirMetaPath,
   bundleDirName,
   defaultPort,
   directories: [],
-  dvlpDir: path.resolve(DIR),
+  dvlpDirPath: path.resolve(DIR_NAME),
   esbuildTargetByExtension: {
     '.js': 'js',
     '.mjs': 'js',

--- a/src/hooks/bundle-dependency.js
+++ b/src/hooks/bundle-dependency.js
@@ -27,6 +27,7 @@ export default async function bundleDependency(filePath, res, esbuild, hookFn) {
     res.metrics.recordEvent(Metrics.EVENT_NAMES.bundle);
 
     const [moduleId, modulePath] = decodeBundleFilePath(filePath);
+    console.log({ moduleId, modulePath });
     let code;
 
     if (!modulePath) {
@@ -87,6 +88,7 @@ export default async function bundleDependency(filePath, res, esbuild, hookFn) {
         code = result.outputFiles[0].text;
       }
     } catch (err) {
+      console.log(err);
       debug(`error bundling "${moduleId}"`);
       res.writeHead(500);
       res.end(/** @type { Error } */ (err).message);

--- a/src/hooks/bundle-dependency.js
+++ b/src/hooks/bundle-dependency.js
@@ -1,13 +1,11 @@
-import { decodeBundleId, encodeOriginalBundledSourcePath } from '../utils/bundling.js';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { basename } from 'path';
 import config from '../config.js';
 import Debug from 'debug';
+import { decodeBundleFilePath } from '../utils/bundling.js';
 import { error } from '../utils/log.js';
 import { isBundledFilePath } from '../utils/is.js';
 import Metrics from '../utils/metrics.js';
 import { parse } from 'cjs-module-lexer';
-import { resolve } from '../resolver/index.js';
 
 const debug = Debug('dvlp:bundle');
 
@@ -28,9 +26,7 @@ export default async function bundleDependency(filePath, res, esbuild, hookFn) {
   if (isBundledFilePath(filePath)) {
     res.metrics.recordEvent(Metrics.EVENT_NAMES.bundle);
 
-    const fileName = basename(filePath);
-    const moduleId = decodeBundleId(fileName.slice(0, fileName.lastIndexOf('-')));
-    const modulePath = resolve(moduleId);
+    const [moduleId, modulePath] = decodeBundleFilePath(filePath);
     let code;
 
     if (!modulePath) {
@@ -100,7 +96,7 @@ export default async function bundleDependency(filePath, res, esbuild, hookFn) {
 
     if (code !== undefined) {
       debug(`bundled content for ${moduleId}`);
-      writeFileSync(filePath, `${encodeOriginalBundledSourcePath(modulePath)}\n${code}`);
+      writeFileSync(filePath, code);
       res.bundled = true;
     }
 

--- a/src/hooks/bundle-dependency.js
+++ b/src/hooks/bundle-dependency.js
@@ -27,7 +27,6 @@ export default async function bundleDependency(filePath, res, esbuild, hookFn) {
     res.metrics.recordEvent(Metrics.EVENT_NAMES.bundle);
 
     const [moduleId, modulePath] = decodeBundleFilePath(filePath);
-    console.log({ moduleId, modulePath });
     let code;
 
     if (!modulePath) {

--- a/src/resolver/package.js
+++ b/src/resolver/package.js
@@ -164,9 +164,20 @@ export function resolvePackagePath(filePath) {
   }
 
   while (true) {
-    // Stop at directory with package.json
-    if (fs.existsSync(path.join(dir, 'package.json'))) {
-      return dir;
+    const pkgPath = path.join(dir, 'package.json');
+
+    // Stop at directory with valid package.json.
+    // "date-fns" includes sub-module package.json files with only side-effect metadata
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const json = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+        if (json.name) {
+          return dir;
+        }
+      } catch (err) {
+        // Ignore
+      }
     }
 
     parent = path.dirname(dir);

--- a/src/server/handlers.js
+++ b/src/server/handlers.js
@@ -175,5 +175,5 @@ export function handleFile(filePath, req, res, cacheControl) {
     maxAge: cacheControl ? config.maxAge : 0,
   };
 
-  send(req, filePath, options).pipe(res);
+  send(req, encodeURI(filePath), options).pipe(res);
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -265,6 +265,7 @@ export default class DvlpServer {
     }
 
     // Allow manual response handling via user hook
+    // TODO: avoid task tick if no user hook registered
     if (await this.hooks.handleRequest(req, res)) {
       return;
     }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -214,6 +214,7 @@ export default class DvlpServer {
     const req = /** @type { Req } */ (request);
     const res = /** @type { Res } */ (response);
     const { url } = req;
+    console.log({ url });
 
     if (isReloadRequest(req)) {
       if (!this.isListening) {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -214,7 +214,6 @@ export default class DvlpServer {
     const req = /** @type { Req } */ (request);
     const res = /** @type { Res } */ (response);
     const { url } = req;
-    console.log({ url });
 
     if (isReloadRequest(req)) {
       if (!this.isListening) {

--- a/src/utils/bundling.js
+++ b/src/utils/bundling.js
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync, unlinkSync } from 'fs';
 import { isJsFilePath, isNodeModuleFilePath } from './is.js';
 import config from '../config.js';
-import { getCachedPackage } from '../resolver/index.js';
+import { getPackageForDir } from '../resolver/index.js';
 import path from 'path';
 
 const RE_SOURCE_PATH = /^\/\/ source: (.+)/;
@@ -41,7 +41,7 @@ export function resolveBundleFileName(id, filePath) {
     return '';
   }
 
-  const pkg = getCachedPackage(path.dirname(filePath));
+  const pkg = getPackageForDir(path.dirname(filePath));
 
   return `${encodeBundleId(id)}-${pkg ? pkg.version : ''}.js`;
 }

--- a/src/utils/bundling.js
+++ b/src/utils/bundling.js
@@ -10,9 +10,8 @@ import path from 'path';
  * @param { string } filePath
  */
 export function encodeBundleFilePath(id, filePath) {
-  const idAndFilePath = encodeURIComponent(`${id}##${filePath}`).replace('/%5C/g', '%2F');
-  console.log({ idAndFilePath });
-  return `${path.join(config.bundleDirName, idAndFilePath)}`.replace('/\\/g', '/');
+  const idAndFilePath = encodeURIComponent(`${id}##${filePath}`.replace(/\\/g, '/'));
+  return `${path.join(config.bundleDirName, idAndFilePath)}`.replace(/\\/g, '/');
 }
 
 /**

--- a/src/utils/bundling.js
+++ b/src/utils/bundling.js
@@ -10,9 +10,9 @@ import path from 'path';
  * @param { string } filePath
  */
 export function encodeBundleFilePath(id, filePath) {
-  id = id.replace('/\\/g', '/');
-  filePath = path.relative(config.bundleDir, filePath).replace('/\\/g', '/');
-  return `${path.join(config.bundleDirName, encodeURIComponent(`${id}##${filePath}`))}`.replace('/\\/g', '/');
+  const idAndFilePath = `${id}##${filePath}`.replace('/\\/g', '/');
+  console.log({ idAndFilePath });
+  return `${path.join(config.bundleDirName, encodeURIComponent(idAndFilePath))}`.replace('/\\/g', '/');
 }
 
 /**

--- a/src/utils/bundling.js
+++ b/src/utils/bundling.js
@@ -1,47 +1,82 @@
 import { existsSync, readdirSync, unlinkSync } from 'fs';
-import { isAbsoluteFilePath, isJsFilePath } from './is.js';
 import config from '../config.js';
+import fs from 'fs';
+import { getPackageForDir } from '../resolver/index.js';
+import { isJsFilePath } from './is.js';
 import path from 'path';
 
+/** @type { Record<string, string> } */
+let meta = {};
+
+if (fs.existsSync(config.bundleDirMetaPath)) {
+  meta = JSON.parse(fs.readFileSync(config.bundleDirMetaPath, 'utf-8'));
+}
+
+process.on('exit', () => {
+  if (!config.testing) {
+    fs.writeFileSync(config.bundleDirMetaPath, JSON.stringify(meta));
+  }
+});
+
 /**
- * Encode bundle "filePath"
+ * Get path to bundle from
  *
- * @param { string } id
- * @param { string } filePath
+ * @param { string } specifier
+ * @param { string } sourcePath
  */
-export function encodeBundleFilePath(id, filePath) {
-  const idAndFilePath = encodeURIComponent(`${id}##${filePath}`.replace(/\\/g, '/'));
-  return `${path.join(config.bundleDirName, idAndFilePath)}`.replace(/\\/g, '/');
+export function getBundlePath(specifier, sourcePath) {
+  const pkg = getPackageForDir(path.dirname(sourcePath));
+  const bundleName = `${encodeBundleSpecifier(specifier)}-${pkg ? pkg.version : ''}.js`;
+  const bundlePath = path.join(config.bundleDirName, bundleName);
+
+  meta[bundleName] = sourcePath;
+
+  return bundlePath;
 }
 
 /**
- * Decode bundle "id" and "filePath"
+ * Get original source path from "bundlePath"
  *
- * @param { string } encodedBundleFilePath
- * @returns { [id: string, filePath: string] }
+ * @param { string } bundlePath
+ * @returns [specifier: string, sourcePath: string]
  */
-export function decodeBundleFilePath(encodedBundleFilePath) {
-  if (!isAbsoluteFilePath(encodedBundleFilePath)) {
-    encodedBundleFilePath = path.resolve(encodedBundleFilePath);
-  }
-  encodedBundleFilePath = decodeURIComponent(path.relative(config.bundleDir, encodedBundleFilePath));
+export function getBundleSourcePath(bundlePath) {
+  const bundleName = path.basename(bundlePath);
+  const specifier = decodeBundleSpecifier(bundleName.split('-')[0]);
+  const sourcePath = meta[bundleName];
 
-  const [id, filePath] = encodedBundleFilePath.split('##');
-
-  return [id, path.resolve(config.bundleDir, filePath)];
+  return [specifier, sourcePath];
 }
 
 /**
  * Clear disk cache
  */
 export function cleanBundledFiles() {
-  if (existsSync(config.bundleDir)) {
-    for (const filePath of readdirSync(config.bundleDir).filter(isJsFilePath)) {
+  if (existsSync(config.bundleDirPath)) {
+    for (const filePath of readdirSync(config.bundleDirPath).filter(isJsFilePath)) {
       try {
-        unlinkSync(path.join(config.bundleDir, filePath));
+        unlinkSync(path.join(config.bundleDirPath, filePath));
       } catch (err) {
         // ignore
       }
     }
   }
+}
+
+/**
+ * Encode "id"
+ *
+ * @param { string } id
+ */
+function encodeBundleSpecifier(id) {
+  return id.replace(/\//g, '__');
+}
+
+/**
+ * Decode "id"
+ *
+ * @param { string } id
+ */
+function decodeBundleSpecifier(id) {
+  return id.replace(/__/g, '/');
 }

--- a/src/utils/bundling.js
+++ b/src/utils/bundling.js
@@ -1,49 +1,33 @@
 import { existsSync, readdirSync, unlinkSync } from 'fs';
-import { isJsFilePath, isNodeModuleFilePath } from './is.js';
+import { isAbsoluteFilePath, isJsFilePath } from './is.js';
 import config from '../config.js';
-import { getPackageForDir } from '../resolver/index.js';
 import path from 'path';
 
-const RE_SOURCE_PATH = /^\/\/ source: (.+)/;
-const SOURCE_PREFIX = '// source: ';
-
 /**
- * Encode bundled source path in banner comment
- *
- * @param { string } sourcePath
- * @returns { string }
- */
-export function encodeOriginalBundledSourcePath(sourcePath) {
-  return `${SOURCE_PREFIX}${sourcePath}`;
-}
-
-/**
- * Retrieve original source path from bundled source code
- *
- * @param { string } code
- * @returns { string }
- */
-export function parseOriginalBundledSourcePath(code) {
-  const match = RE_SOURCE_PATH.exec(code);
-
-  return match && match[1] ? match[1] : '';
-}
-
-/**
- * Resolve module id into bundle file name
+ * Encode bundle "filePath"
  *
  * @param { string } id
  * @param { string } filePath
- * @returns { string }
  */
-export function resolveBundleFileName(id, filePath) {
-  if (!isNodeModuleFilePath(filePath)) {
-    return '';
+export function encodeBundleFilePath(id, filePath) {
+  filePath = path.relative(config.bundleDir, filePath);
+  return `${path.join(config.bundleDirName, encodeURIComponent(`${id}##${filePath}`))}`;
+}
+
+/**
+ * Decode bundle "id" and "filePath"
+ *
+ * @param { string } encodedBundleFilePath
+ * @returns { [id: string, filePath: string] }
+ */
+export function decodeBundleFilePath(encodedBundleFilePath) {
+  if (!isAbsoluteFilePath(encodedBundleFilePath)) {
+    encodedBundleFilePath = path.resolve(encodedBundleFilePath);
   }
+  encodedBundleFilePath = decodeURIComponent(path.relative(config.bundleDir, encodedBundleFilePath));
+  const [id, filePath] = encodedBundleFilePath.split('##');
 
-  const pkg = getPackageForDir(path.dirname(filePath));
-
-  return `${encodeBundleId(id)}-${pkg ? pkg.version : ''}.js`;
+  return [id, path.resolve(config.bundleDir, filePath)];
 }
 
 /**
@@ -59,22 +43,4 @@ export function cleanBundledFiles() {
       }
     }
   }
-}
-
-/**
- * Encode "id"
- *
- * @param { string } id
- */
-export function encodeBundleId(id) {
-  return id.replace(/\//g, '__');
-}
-
-/**
- * Decode "id"
- *
- * @param { string } id
- */
-export function decodeBundleId(id) {
-  return id.replace(/__/g, '/');
 }

--- a/src/utils/bundling.js
+++ b/src/utils/bundling.js
@@ -10,9 +10,9 @@ import path from 'path';
  * @param { string } filePath
  */
 export function encodeBundleFilePath(id, filePath) {
-  const idAndFilePath = `${id}##${filePath}`.replace('/\\\\/g', '/');
+  const idAndFilePath = encodeURIComponent(`${id}##${filePath}`).replace('/%5C/g', '%2F');
   console.log({ idAndFilePath });
-  return `${path.join(config.bundleDirName, encodeURIComponent(idAndFilePath))}`.replace('/\\/g', '/');
+  return `${path.join(config.bundleDirName, idAndFilePath)}`.replace('/\\/g', '/');
 }
 
 /**

--- a/src/utils/bundling.js
+++ b/src/utils/bundling.js
@@ -21,15 +21,13 @@ export function encodeBundleFilePath(id, filePath) {
  * @returns { [id: string, filePath: string] }
  */
 export function decodeBundleFilePath(encodedBundleFilePath) {
-  console.log('decodeBundleFilePath', encodedBundleFilePath);
   if (!isAbsoluteFilePath(encodedBundleFilePath)) {
     encodedBundleFilePath = path.resolve(encodedBundleFilePath);
   }
-  console.log(encodedBundleFilePath);
-  console.log(path.relative(config.bundleDir, encodedBundleFilePath));
   encodedBundleFilePath = decodeURIComponent(path.relative(config.bundleDir, encodedBundleFilePath));
+
   const [id, filePath] = encodedBundleFilePath.split('##');
-  console.log({ id, filePath });
+
   return [id, path.resolve(config.bundleDir, filePath)];
 }
 

--- a/src/utils/bundling.js
+++ b/src/utils/bundling.js
@@ -10,7 +10,7 @@ import path from 'path';
  * @param { string } filePath
  */
 export function encodeBundleFilePath(id, filePath) {
-  const idAndFilePath = `${id}##${filePath}`.replace('/\\/g', '/');
+  const idAndFilePath = `${id}##${filePath}`.replace('/\\\\/g', '/');
   console.log({ idAndFilePath });
   return `${path.join(config.bundleDirName, encodeURIComponent(idAndFilePath))}`.replace('/\\/g', '/');
 }

--- a/src/utils/bundling.js
+++ b/src/utils/bundling.js
@@ -21,12 +21,15 @@ export function encodeBundleFilePath(id, filePath) {
  * @returns { [id: string, filePath: string] }
  */
 export function decodeBundleFilePath(encodedBundleFilePath) {
+  console.log('decodeBundleFilePath', encodedBundleFilePath);
   if (!isAbsoluteFilePath(encodedBundleFilePath)) {
     encodedBundleFilePath = path.resolve(encodedBundleFilePath);
   }
+  console.log(encodedBundleFilePath);
+  console.log(path.relative(config.bundleDir, encodedBundleFilePath));
   encodedBundleFilePath = decodeURIComponent(path.relative(config.bundleDir, encodedBundleFilePath));
   const [id, filePath] = encodedBundleFilePath.split('##');
-
+  console.log({ id, filePath });
   return [id, path.resolve(config.bundleDir, filePath)];
 }
 

--- a/src/utils/bundling.js
+++ b/src/utils/bundling.js
@@ -10,8 +10,9 @@ import path from 'path';
  * @param { string } filePath
  */
 export function encodeBundleFilePath(id, filePath) {
-  filePath = path.relative(config.bundleDir, filePath);
-  return `${path.join(config.bundleDirName, encodeURIComponent(`${id}##${filePath}`))}`;
+  id = id.replace('/\\/g', '/');
+  filePath = path.relative(config.bundleDir, filePath).replace('/\\/g', '/');
+  return `${path.join(config.bundleDirName, encodeURIComponent(`${id}##${filePath}`))}`.replace('/\\/g', '/');
 }
 
 /**

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -118,7 +118,7 @@ export function find(req, { directories = config.directories, type } = {}) {
 
   // Handle bundled js import
   if (isBundledUrl(href)) {
-    filePath = path.join(config.bundleDir, path.basename(href));
+    filePath = path.resolve(href.slice(1));
   } else if (isAbsoluteFilePath(href)) {
     filePath = resolveFilePath(href, type);
   } else {

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -118,6 +118,7 @@ export function find(req, { directories = config.directories, type } = {}) {
 
   // Handle bundled js import
   if (isBundledUrl(href)) {
+    // Remove leading "/"
     filePath = path.resolve(href.slice(1));
   } else if (isAbsoluteFilePath(href)) {
     filePath = resolveFilePath(href, type);

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -11,9 +11,7 @@ export const WARN_CERTIFICATE_EXPIRY = '⚠️  ssl certificate will expire soon
 
 const SEG_LENGTH = 80;
 
-let maxBareImport = 1;
-let maxMissingExtension = 1;
-let maxPackageIndex = 1;
+const seenWarnings = new Set();
 let silent = false;
 
 export default {
@@ -56,33 +54,28 @@ export function noisyInfo(msg) {
  */
 export function warn(...args) {
   if (!config.testing && !silent) {
-    const [warning] = args;
-    let msg = '';
+    const warning = args.join(' ');
 
-    switch (warning) {
-      case WARN_BARE_IMPORT:
-        if (maxBareImport-- > 0) {
-          msg = `${WARN_BARE_IMPORT}`;
-        }
-        break;
-      case WARN_MISSING_EXTENSION:
-        if (maxMissingExtension-- > 0) {
-          msg = `${WARN_MISSING_EXTENSION}`;
-        }
-        break;
-      case WARN_PACKAGE_INDEX:
-        if (maxPackageIndex-- > 0) {
-          msg = `${WARN_PACKAGE_INDEX}`;
-        }
-        break;
-      default:
-        msg = args.join(' ');
+    // Only warn one time
+    if (seenWarnings.has(warning)) {
+      return;
     }
+    seenWarnings.add(warning);
 
-    if (msg) {
-      console.warn(msg);
-    }
+    console.warn(warning);
   }
+}
+
+/**
+ * Warn if not testing, even if silent
+ *
+ * @param { ...unknown } args
+ */
+export function noisyWarn(...args) {
+  const initialValue = silent;
+  silent = false;
+  warn(...args);
+  silent = initialValue;
 }
 
 /**

--- a/src/utils/patch.js
+++ b/src/utils/patch.js
@@ -1,4 +1,5 @@
 import { brotliDecompressSync, unzipSync } from 'zlib';
+import { decodeBundleFilePath, encodeBundleFilePath } from './bundling.js';
 import { fatal, warn, WARN_BARE_IMPORT } from './log.js';
 import { getAbsoluteProjectPath, getProjectPath, isEsmFile } from './file.js';
 import {
@@ -9,8 +10,6 @@ import {
   isJsRequest,
   isNodeModuleFilePath,
 } from './is.js';
-import { parseOriginalBundledSourcePath, resolveBundleFileName } from './bundling.js';
-import config from '../config.js';
 import Debug from 'debug';
 import { filePathToUrl } from './url.js';
 import Metrics from './metrics.js';
@@ -311,10 +310,10 @@ function rewriteCSSImports(res, filePath, css, resolveImport) {
 function rewriteJSImports(res, filePath, js, resolveImport) {
   res.metrics.recordEvent(Metrics.EVENT_NAMES.imports);
 
-  // Retrieve original source path from bundled file
+  // Retrieve original source path from bundled filePath
   // to allow reference back to correct node_modules file
   if (isBundledFilePath(filePath)) {
-    filePath = parseOriginalBundledSourcePath(js);
+    [, filePath] = decodeBundleFilePath(filePath);
   }
 
   try {
@@ -391,8 +390,7 @@ function rewriteJSImports(res, filePath, js, resolveImport) {
 
           // Bundle if in node_modules and not an es module
           if (isNodeModuleFilePath(importPath) && !isEsmFile(importPath)) {
-            const resolvedId = resolveBundleFileName(specifier, importPath);
-            newId = `/${path.join(config.bundleDirName, resolvedId)}`;
+            newId = `/${encodeBundleFilePath(specifier, importPath)}`;
             warn(WARN_BARE_IMPORT, specifier);
           } else {
             newId = importPath;

--- a/src/utils/patch.js
+++ b/src/utils/patch.js
@@ -1,7 +1,7 @@
 import { brotliDecompressSync, unzipSync } from 'zlib';
-import { decodeBundleFilePath, encodeBundleFilePath } from './bundling.js';
 import { fatal, warn, WARN_BARE_IMPORT } from './log.js';
 import { getAbsoluteProjectPath, getProjectPath, isEsmFile } from './file.js';
+import { getBundlePath, getBundleSourcePath } from './bundling.js';
 import {
   isBundledFilePath,
   isBundledUrl,
@@ -313,7 +313,7 @@ function rewriteJSImports(res, filePath, js, resolveImport) {
   // Retrieve original source path from bundled filePath
   // to allow reference back to correct node_modules file
   if (isBundledFilePath(filePath)) {
-    [, filePath] = decodeBundleFilePath(filePath);
+    [, filePath] = getBundleSourcePath(filePath);
   }
 
   try {
@@ -390,7 +390,7 @@ function rewriteJSImports(res, filePath, js, resolveImport) {
 
           // Bundle if in node_modules and not an es module
           if (isNodeModuleFilePath(importPath) && !isEsmFile(importPath)) {
-            newId = `/${encodeBundleFilePath(specifier, importPath)}`;
+            newId = `/${getBundlePath(specifier, importPath)}`;
             warn(WARN_BARE_IMPORT, specifier);
           } else {
             newId = importPath;

--- a/src/utils/watch.js
+++ b/src/utils/watch.js
@@ -53,7 +53,7 @@ export default function watch(fn) {
       if (
         !files.has(filePath) &&
         !filePath.startsWith(tmpdir) &&
-        !filePath.startsWith(config.dvlpDir) &&
+        !filePath.startsWith(config.dvlpDirPath) &&
         !path.basename(filePath).startsWith('.')
       ) {
         debug(`watching file "${getProjectPath(filePath)}"`);

--- a/test/unit/fixtures/resolver/node_modules/@popeindustries/test/node_modules/versioned/package.json
+++ b/test/unit/fixtures/resolver/node_modules/@popeindustries/test/node_modules/versioned/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "versioned",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/unit/fixtures/resolver/node_modules/foo/node_modules/versioned/package.json
+++ b/test/unit/fixtures/resolver/node_modules/foo/node_modules/versioned/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "versioned",
+  "version": "2.0.0",
+  "main": "index.js"
+}

--- a/test/unit/fixtures/resolver/node_modules/versioned/package.json
+++ b/test/unit/fixtures/resolver/node_modules/versioned/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "versioned",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/unit/hooks-test.js
+++ b/test/unit/hooks-test.js
@@ -41,9 +41,9 @@ describe('hooks()', () => {
       const hooks = new Hooks();
       expect(await hooks.bundleDependency('./dvlp/bundle-xxx/foofoo-0.0.0.js')).to.equal(undefined);
     });
-    it('should bundle filePath', async () => {
+    it.only('should bundle filePath', async () => {
       const hooks = new Hooks();
-      const filePath = getBundleFilePath('debug');
+      const filePath = path.resolve(getBundleFilePath('debug'));
       await hooks.bundleDependency(filePath, getResponse());
       const module = fs.readFileSync(filePath, 'utf8');
       expect(module).to.include('export_default as default');

--- a/test/unit/hooks-test.js
+++ b/test/unit/hooks-test.js
@@ -1,15 +1,12 @@
-import config from '../../src/config.js';
 import { expect } from 'chai';
 import fs from 'fs';
+import { getBundleFilePath } from './utils.js';
 import Hooks from '../../src/hooks/index.js';
 import hooksFixture from './fixtures/hooks-bundle.mjs';
 import { init } from 'cjs-module-lexer';
 import path from 'path';
 import transformBundleFixture from './fixtures/hooks-transform-bundle.mjs';
 import transformFixture from './fixtures/hooks-transform.mjs';
-
-const DEBUG = 'debug-4.3.3.js';
-const REACT = 'react-17.0.1.js';
 
 function getResponse() {
   return {
@@ -46,14 +43,14 @@ describe('hooks()', () => {
     });
     it('should bundle filePath', async () => {
       const hooks = new Hooks();
-      const filePath = path.join(config.bundleDir, DEBUG);
+      const filePath = getBundleFilePath('debug');
       await hooks.bundleDependency(filePath, getResponse());
       const module = fs.readFileSync(filePath, 'utf8');
       expect(module).to.include('export_default as default');
     });
     it('should bundle and add missing named exports', async () => {
       const hooks = new Hooks();
-      const filePath = path.join(config.bundleDir, REACT);
+      const filePath = getBundleFilePath('react');
       await hooks.bundleDependency(filePath, getResponse());
       const module = fs.readFileSync(filePath, 'utf8');
       expect(module).to.include('export_default as default');
@@ -61,7 +58,7 @@ describe('hooks()', () => {
     });
     it('should return cached bundle', async () => {
       const hooks = new Hooks();
-      const filePath = path.join(config.bundleDir, DEBUG);
+      const filePath = getBundleFilePath('debug');
       fs.writeFileSync(filePath, 'this is cached');
       await hooks.bundleDependency(filePath, getResponse());
       const module = fs.readFileSync(filePath, 'utf8');
@@ -70,7 +67,7 @@ describe('hooks()', () => {
     });
     it('should bundle with custom hook', async () => {
       const hooks = new Hooks(hooksFixture);
-      const filePath = path.join(config.bundleDir, DEBUG);
+      const filePath = getBundleFilePath('debug');
       await hooks.bundleDependency(filePath, getResponse());
       const module = fs.readFileSync(filePath, 'utf8');
       expect(module).to.contain('this is bundled content for: browser.js');

--- a/test/unit/hooks-test.js
+++ b/test/unit/hooks-test.js
@@ -32,7 +32,7 @@ describe('hooks()', () => {
     await init();
   });
 
-  describe('bundle', () => {
+  describe.only('bundle', () => {
     afterEach(() => {
       hooks && hooks.destroy();
     });
@@ -41,7 +41,7 @@ describe('hooks()', () => {
       const hooks = new Hooks();
       expect(await hooks.bundleDependency('./dvlp/bundle-xxx/foofoo-0.0.0.js')).to.equal(undefined);
     });
-    it.only('should bundle filePath', async () => {
+    it('should bundle filePath', async () => {
       const hooks = new Hooks();
       const filePath = path.resolve(getBundleFilePath('debug'));
       await hooks.bundleDependency(filePath, getResponse());
@@ -50,7 +50,7 @@ describe('hooks()', () => {
     });
     it('should bundle and add missing named exports', async () => {
       const hooks = new Hooks();
-      const filePath = getBundleFilePath('react');
+      const filePath = path.resolve(getBundleFilePath('react'));
       await hooks.bundleDependency(filePath, getResponse());
       const module = fs.readFileSync(filePath, 'utf8');
       expect(module).to.include('export_default as default');
@@ -58,7 +58,7 @@ describe('hooks()', () => {
     });
     it('should return cached bundle', async () => {
       const hooks = new Hooks();
-      const filePath = getBundleFilePath('debug');
+      const filePath = path.resolve(getBundleFilePath('debug'));
       fs.writeFileSync(filePath, 'this is cached');
       await hooks.bundleDependency(filePath, getResponse());
       const module = fs.readFileSync(filePath, 'utf8');
@@ -67,7 +67,7 @@ describe('hooks()', () => {
     });
     it('should bundle with custom hook', async () => {
       const hooks = new Hooks(hooksFixture);
-      const filePath = getBundleFilePath('debug');
+      const filePath = path.resolve(getBundleFilePath('debug'));
       await hooks.bundleDependency(filePath, getResponse());
       const module = fs.readFileSync(filePath, 'utf8');
       expect(module).to.contain('this is bundled content for: browser.js');

--- a/test/unit/hooks-test.js
+++ b/test/unit/hooks-test.js
@@ -32,7 +32,7 @@ describe('hooks()', () => {
     await init();
   });
 
-  describe.only('bundle', () => {
+  describe('bundle', () => {
     afterEach(() => {
       hooks && hooks.destroy();
     });

--- a/test/unit/patch-test.js
+++ b/test/unit/patch-test.js
@@ -7,8 +7,6 @@ import { patchResponse } from '../../src/utils/patch.js';
 import path from 'path';
 import { ServerResponse } from 'http';
 
-const DEBUG_VERSION = '4.3.3';
-
 const cwd = process
   .cwd()
   .replace(/^[A-Z]:\\/, '/')
@@ -356,7 +354,7 @@ describe('patch', () => {
             resolveImport: hooks.resolveImport,
           });
           res.end('import debug from "debug";');
-          expect(getBody(res)).to.equal(`import debug from "/${bundleDir}/debug-${DEBUG_VERSION}.js";`);
+          expect(getBody(res)).to.include(`import debug from "/${bundleDir}/debug`);
         });
         it('should escape "$" when resolving js import id', () => {
           const req = getRequest('/index.js', {
@@ -378,9 +376,7 @@ describe('patch', () => {
             resolveImport: hooks.resolveImport,
           });
           res.end(`const foo = 'bar'\nimport debug from "debug";`);
-          expect(getBody(res)).to.equal(
-            `const foo = 'bar'\nimport debug from "/${bundleDir}/debug-${DEBUG_VERSION}.js";`,
-          );
+          expect(getBody(res)).to.include(`const foo = 'bar'\nimport debug from "/${bundleDir}/debug`);
         });
         it('should resolve import following a semi-colon', () => {
           const req = getRequest('/index.js', {
@@ -391,8 +387,8 @@ describe('patch', () => {
             resolveImport: hooks.resolveImport,
           });
           res.end(`function foo(value) { return value; };import debug from "debug";`);
-          expect(getBody(res)).to.equal(
-            `function foo(value) { return value; };import debug from "/${bundleDir}/debug-${DEBUG_VERSION}.js";`,
+          expect(getBody(res)).to.include(
+            `function foo(value) { return value; };import debug from "/${bundleDir}/debug`,
           );
         });
         it('should resolve import following a closing curly bracket', () => {
@@ -404,8 +400,8 @@ describe('patch', () => {
             resolveImport: hooks.resolveImport,
           });
           res.end(`function foo(value) { return value; } import debug from "debug";`);
-          expect(getBody(res)).to.equal(
-            `function foo(value) { return value; } import debug from "/${bundleDir}/debug-${DEBUG_VERSION}.js";`,
+          expect(getBody(res)).to.include(
+            `function foo(value) { return value; } import debug from "/${bundleDir}/debug`,
           );
         });
         it('should resolve import following a closing parethesis', () => {
@@ -417,9 +413,7 @@ describe('patch', () => {
             resolveImport: hooks.resolveImport,
           });
           res.end(`const foo = ('bar') import debug from "debug";`);
-          expect(getBody(res)).to.equal(
-            `const foo = ('bar') import debug from "/${bundleDir}/debug-${DEBUG_VERSION}.js";`,
-          );
+          expect(getBody(res)).to.include(`const foo = ('bar') import debug from "/${bundleDir}/debug`);
         });
         it('should not resolve import following an invalid character', () => {
           const req = getRequest('/index.js', {
@@ -444,9 +438,9 @@ describe('patch', () => {
           res.end(
             'import debugBrowser from "debug/src/browser.js";\nimport { foo } from "./foo.js";\nimport debug from "debug";',
           );
-          expect(getBody(res)).to.equal(
-            `import debugBrowser from "/${bundleDir}/debug__src__browser.js-${DEBUG_VERSION}.js";\nimport { foo } from "./foo.js";\nimport debug from "/${bundleDir}/debug-${DEBUG_VERSION}.js";`,
-          );
+          const body = getBody(res);
+          expect(body).to.include('import debugBrowser from "/.dvlp/bundle-dev/debug');
+          expect(body).to.include('import debug from "/.dvlp/bundle-dev/debug');
         });
         it('should resolve bare js import id for es module', () => {
           const req = getRequest('/index.js', {
@@ -556,9 +550,9 @@ describe('patch', () => {
             resolveImport: hooks.resolveImport,
           });
           res.end('import debugBrowser from "debug/src/browser.js";\nimport(foo);\nimport("debug");\n');
-          expect(getBody(res)).to.equal(
-            `import debugBrowser from "/${bundleDir}/debug__src__browser.js-${DEBUG_VERSION}.js";\nimport(foo);\nimport("/${bundleDir}/debug-${DEBUG_VERSION}.js");\n`,
-          );
+          const body = getBody(res);
+          expect(body).to.include('import debugBrowser from "/.dvlp/bundle-dev/debug');
+          expect(body).to.include('import("/.dvlp/bundle-dev/debug');
         });
         it('should resolve js import with resolve hook', () => {
           const req = getRequest('/index.js', {

--- a/test/unit/patch-test.js
+++ b/test/unit/patch-test.js
@@ -439,8 +439,8 @@ describe('patch', () => {
             'import debugBrowser from "debug/src/browser.js";\nimport { foo } from "./foo.js";\nimport debug from "debug";',
           );
           const body = getBody(res);
-          expect(body).to.include(`import debugBrowser from "/${config.bundleDirName}/debug__src__browser.js-`);
-          expect(body).to.include(`import debug from "/${config.bundleDirName}/debug-`);
+          expect(body).to.include(`import debugBrowser from "/${bundleDir}/debug__src__browser.js-`);
+          expect(body).to.include(`import debug from "/${bundleDir}/debug-`);
         });
         it('should resolve bare js import id for es module', () => {
           const req = getRequest('/index.js', {
@@ -551,8 +551,8 @@ describe('patch', () => {
           });
           res.end('import debugBrowser from "debug/src/browser.js";\nimport(foo);\nimport("debug");\n');
           const body = getBody(res);
-          expect(body).to.include(`import debugBrowser from "/${config.bundleDirName}/debug__src__browser.js-`);
-          expect(body).to.include(`import("/${config.bundleDirName}/debug-`);
+          expect(body).to.include(`import debugBrowser from "/${bundleDir}/debug__src__browser.js-`);
+          expect(body).to.include(`import("/${bundleDir}/debug-`);
         });
         it('should resolve js import with resolve hook', () => {
           const req = getRequest('/index.js', {

--- a/test/unit/patch-test.js
+++ b/test/unit/patch-test.js
@@ -439,8 +439,8 @@ describe('patch', () => {
             'import debugBrowser from "debug/src/browser.js";\nimport { foo } from "./foo.js";\nimport debug from "debug";',
           );
           const body = getBody(res);
-          expect(body).to.include('import debugBrowser from "/.dvlp/bundle-dev/debug');
-          expect(body).to.include('import debug from "/.dvlp/bundle-dev/debug');
+          expect(body).to.include(`import debugBrowser from "/${config.bundleDirName}/debug__src__browser.js-`);
+          expect(body).to.include(`import debug from "/${config.bundleDirName}/debug-`);
         });
         it('should resolve bare js import id for es module', () => {
           const req = getRequest('/index.js', {
@@ -551,8 +551,9 @@ describe('patch', () => {
           });
           res.end('import debugBrowser from "debug/src/browser.js";\nimport(foo);\nimport("debug");\n');
           const body = getBody(res);
-          expect(body).to.include('import debugBrowser from "/.dvlp/bundle-dev/debug');
-          expect(body).to.include('import("/.dvlp/bundle-dev/debug');
+          console.log(body);
+          expect(body).to.include(`import debugBrowser from "/${config.bundleDirName}/debug__src__browser.js-`);
+          expect(body).to.include(`import("/${config.bundleDirName}/debug-`);
         });
         it('should resolve js import with resolve hook', () => {
           const req = getRequest('/index.js', {

--- a/test/unit/patch-test.js
+++ b/test/unit/patch-test.js
@@ -551,7 +551,6 @@ describe('patch', () => {
           });
           res.end('import debugBrowser from "debug/src/browser.js";\nimport(foo);\nimport("debug");\n');
           const body = getBody(res);
-          console.log(body);
           expect(body).to.include(`import debugBrowser from "/${config.bundleDirName}/debug__src__browser.js-`);
           expect(body).to.include(`import("/${config.bundleDirName}/debug-`);
         });

--- a/test/unit/resolver-test.js
+++ b/test/unit/resolver-test.js
@@ -136,6 +136,13 @@ describe('resolver', () => {
         path.resolve('node_modules/foo/lib/bat.js'),
       );
     });
+    it('should resolve same js package module path with same version', () => {
+      const v1 = path.resolve('node_modules/versioned/index.js');
+      const v2 = path.resolve('node_modules/foo/node_modules/versioned/index.js');
+      expect(resolve('versioned', path.resolve('foo.js'))).to.equal(v1);
+      expect(resolve('versioned', path.resolve('node_modules/foo/index.js'))).to.equal(v2);
+      expect(resolve('versioned', path.resolve('node_modules/@popeindustries/test/test.js'))).to.equal(v1);
+    });
     it('should resolve a scoped js package module path containing a package.json file and a "main" file field', () => {
       expect(resolve('@popeindustries/test', path.resolve('baz.js'))).to.equal(
         path.resolve('node_modules/@popeindustries/test/test.js'),

--- a/test/unit/server-test.js
+++ b/test/unit/server-test.js
@@ -86,10 +86,9 @@ describe('server', () => {
       expect(res.status).to.eql(200);
       expect(res.headers.get('Content-type')).to.include('application/javascript');
     });
-    it.only('should serve a bundled module js file with correct mime type', async () => {
+    it('should serve a bundled module js file with correct mime type', async () => {
       server = await serverFactory('test/unit/fixtures/www', { port: 8100 });
       const href = getBundleFilePath('debug');
-      console.log({ href });
       const res = await fetch(`http://localhost:8100/${href}`);
       expect(res.status).to.eql(200);
       expect(res.headers.get('Content-type')).to.include('application/javascript');

--- a/test/unit/server-test.js
+++ b/test/unit/server-test.js
@@ -4,13 +4,12 @@ import EventSource from 'eventsource';
 import { expect } from 'chai';
 import fetch from 'node-fetch';
 import { fileURLToPath } from 'url';
+import { getBundleFilePath } from './utils.js';
 import http from 'http';
 import http2 from 'http2';
 import path from 'path';
 import { server as serverFactory } from '../../src/dvlp.js';
 import websocket from 'faye-websocket';
-
-const DEBUG_VERSION = '4.3.3';
 
 const { Client: WebSocket } = websocket;
 let es, server, ws;
@@ -89,7 +88,7 @@ describe('server', () => {
     });
     it('should serve a bundled module js file with correct mime type', async () => {
       server = await serverFactory('test/unit/fixtures/www', { port: 8100 });
-      const res = await fetch(`http://localhost:8100/${config.bundleDirName}/debug-${DEBUG_VERSION}.js`);
+      const res = await fetch(`http://localhost:8100/${getBundleFilePath('debug')}`);
       expect(res.status).to.eql(200);
       expect(res.headers.get('Content-type')).to.include('application/javascript');
     });
@@ -446,7 +445,7 @@ describe('server', () => {
     });
     it('should serve a bundled module js file', async () => {
       server = await serverFactory('test/unit/fixtures/app.mjs', { port: 8100 });
-      const res = await fetch(`http://localhost:8100/${config.bundleDirName}/debug-${DEBUG_VERSION}.js`);
+      const res = await fetch(`http://localhost:8100/${getBundleFilePath('debug')}`);
       expect(res.status).to.eql(200);
       const body = await res.text();
       expect(body).to.contain('function parse(str)');
@@ -456,7 +455,7 @@ describe('server', () => {
       server = await serverFactory('test/unit/fixtures/app-listener.mjs', {
         port: 8100,
       });
-      const res = await fetch(`http://localhost:8100/${config.bundleDirName}/debug-${DEBUG_VERSION}.js`);
+      const res = await fetch(`http://localhost:8100/${getBundleFilePath('debug')}`);
       expect(res.status).to.eql(200);
       const body = await res.text();
       expect(body).to.contain('function parse(str)');

--- a/test/unit/server-test.js
+++ b/test/unit/server-test.js
@@ -86,9 +86,11 @@ describe('server', () => {
       expect(res.status).to.eql(200);
       expect(res.headers.get('Content-type')).to.include('application/javascript');
     });
-    it('should serve a bundled module js file with correct mime type', async () => {
+    it.only('should serve a bundled module js file with correct mime type', async () => {
       server = await serverFactory('test/unit/fixtures/www', { port: 8100 });
-      const res = await fetch(`http://localhost:8100/${getBundleFilePath('debug')}`);
+      const href = getBundleFilePath('debug');
+      console.log({ href });
+      const res = await fetch(`http://localhost:8100/${href}`);
       expect(res.status).to.eql(200);
       expect(res.headers.get('Content-type')).to.include('application/javascript');
     });

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,6 @@
+import { encodeBundleFilePath } from '../../src/utils/bundling.js';
+import { resolve } from '../../src/resolver/index.js';
+
+export function getBundleFilePath(id) {
+  return encodeBundleFilePath(id, resolve(id));
+}

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,6 +1,6 @@
-import { encodeBundleFilePath } from '../../src/utils/bundling.js';
+import { getBundlePath } from '../../src/utils/bundling.js';
 import { resolve } from '../../src/resolver/index.js';
 
-export function getBundleFilePath(id) {
-  return encodeBundleFilePath(id, resolve(id));
+export function getBundleFilePath(specifier) {
+  return getBundlePath(specifier, resolve(specifier));
 }


### PR DESCRIPTION
- eliminate multiple copies of same version when resolving packages
- add multiple version package warning
- store original source file path in bundle metadata file to correctly resolve back to original from request
- update .dvlp directory structure