### PR TITLE
Typescript definition files should referer to `dvlp.js` with `js` extension.

### DIFF
--- a/src/dvlp-test-browser.d.ts
+++ b/src/dvlp-test-browser.d.ts
@@ -1,4 +1,4 @@
-import { MockRequest, MockResponse, MockResponseHandler, PushEvent } from './dvlp';
+import { MockRequest, MockResponse, MockResponseHandler, PushEvent } from './dvlp.js';
 
 export { MockRequest, MockResponse, MockResponseHandler, PushEvent };
 

--- a/src/dvlp-test.d.ts
+++ b/src/dvlp-test.d.ts
@@ -1,4 +1,4 @@
-import { Req, Res, TestServer, TestServerOptions } from './dvlp';
+import { Req, Res, TestServer, TestServerOptions } from './dvlp.js';
 
 export { Req, Res, TestServer, TestServerOptions };
 


### PR DESCRIPTION
## Background 
The typescript definition files for dvlp-test-browser.d.ts and dvlp-test.d.ts should referer to `./dvlp.js` not `./dvlp`
Currently not getting the correct import in a ESM project, i get the following issue in VSCode here 👇🏽 
![Screenshot 2022-08-29 at 13 45 13](https://user-images.githubusercontent.com/155505/187193903-de34a6a7-a4d9-4c71-94eb-3fc531e37cae.png)

## Solution
By setting the `.js` extension VSCode stop complaining and we get the correct auto completion. 👇🏽 
![Screenshot 2022-08-29 at 13 46 50](https://user-images.githubusercontent.com/155505/187194148-d55596e4-5522-4781-851e-bba64af606ed.png)
