### PR TITLE
 Update _.d.ts

### DIFF
--- a/src/hooks/_.d.ts
+++ b/src/hooks/_.d.ts
@@ -8,7 +8,7 @@ declare interface Hooks {
     filePath: string,
     fileContents: string,
     context: DependencyBundleHookContext,
-  ): Promise<string> | string | undefined;
+  ): Promise<string | undefined> | string | undefined;
   /**
    * Transform file contents for file requested by the browser.
    * This hook is run after file read, and before any modifications by dvlp.
@@ -17,7 +17,7 @@ declare interface Hooks {
     filePath: string,
     fileContents: string,
     context: TransformHookContext,
-  ): Promise<string> | string | undefined;
+  ): Promise<string | undefined> | string | undefined;
   /**
    * Manually resolve import specifier.
    * This hook is run for each import statement.
@@ -37,7 +37,7 @@ declare interface Hooks {
   onRequest?(
     request: IncomingMessage | Http2ServerRequest,
     response: ServerResponse | Http2ServerResponse,
-  ): Promise<boolean> | boolean | undefined;
+  ): Promise<boolean | undefined> | boolean | undefined;
   /**
    * Modify response body before sending to the browser.
    * This hook is run after all modifications by dvlp, and before sending to the browser.


### PR DESCRIPTION
Updates return promise types to be 1-1 with the sync version.

The problem is that if we use async/await syntax for one of these hookes is used, we must always return the type of of the promise and not undefined e.g.:
```ts
async onTransform(filePath, fileContents, context) {
  // We must alway return a string here from this function
  // returning a undefined value here yields a type error.
}
```

vs.
```ts
onTransform(filePath, fileContents, context) {
  // Here we can return a string, undefined or a Promise<string>
  // but we can't use async/await syntax
}
```

## Example
Here's an error that we get 👋🏽 
![Screenshot 2023-10-14 at 20 49 12](https://github.com/popeindustries/dvlp/assets/155505/e817636e-61d3-4265-ae48-ab8efffd8b27)

I fixed this manually be using sync version instead here, however would be nice if the types are consistent 👍🏽, from what i saw in the dvlp code it does not care whether the underlying function is a promise or not since it just await's the result from the hookFn function and checks whether the result is undefined or not. So the type changes here would not have any difference to say, just more practical 😊 