### PR TITLE
Add mime-type video/mp4 for file-ending .mp4 in mime util

### DIFF
--- a/src/utils/mime.js
+++ b/src/utils/mime.js
@@ -17,6 +17,7 @@ const TYPES = {
   'font/ttf': ['.ttf'],
   'font/woff': ['.woff'],
   'font/woff2': ['.woff2'],
+  'video/mp4': ['.mp4'],
 };
 
 /**


### PR DESCRIPTION
Some video playing clients are not happy when getting `applicaiton/octet-stream` as the mime-type for mpeg4 video. This should fix it. 