### PR TITLE
add back common name

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -76,15 +76,17 @@ export class Dvlp {
     this.secureServerOptions;
 
     let protocol = 'http';
-
+    let commonName = undefined;
     if (certsPath) {
       const serverOptions = resolveCerts(certsPath);
-      validateCert(serverOptions.cert);
+      commonName = validateCert(serverOptions.cert);
       this.secureServerOptions = { allowHTTP1: true, ...serverOptions };
       protocol = 'https';
     }
-
-    this.origin = `${protocol}://localhost:${port}`;
+    this.origin = commonName
+        ? `https://${commonName}`
+        : `${protocol}://localhost:${port}`;
+    
     // Make sure mocks instance has access to active port
     this.port = config.activePort = port;
     this.mocks = new Mocks(mockPath);


### PR DESCRIPTION
We are missing the common name here, now it says `https://localhost:443`:

![Skjermbilde 2024-05-07 kl  15 21 39](https://github.com/popeindustries/dvlp/assets/155505/06c2d0e9-0435-494b-a60c-b8432d05181f)


before it used the common name from the certificate e.g.:
![Skjermbilde 2024-05-07 kl  15 27 50](https://github.com/popeindustries/dvlp/assets/155505/119119fa-7b5e-4273-b6c3-13930cf653ec)

We often click this link directly from the terminal.